### PR TITLE
A mixed-in module's class_eval gets evaluated repeatedly on same class

### DIFF
--- a/lib/with_model/dsl.rb
+++ b/lib/with_model/dsl.rb
@@ -30,9 +30,10 @@ module WithModel
       original_const_defined = Object.const_defined?(const_name)
       original_const_value = Object.const_get(const_name) if original_const_defined
 
-      model = Class.new(WithModel::Base)
+      model = nil
 
       @example_group.before do
+        model = Class.new(WithModel::Base)
         silence_warnings { Object.const_set(const_name, model) }
         Object.const_get(const_name).class_eval do
           set_table_name table_name

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -139,6 +139,36 @@ describe "a temporary ActiveRecord model created with with_model" do
     end
   end
 
+  context "with a mixin that has a class_eval" do
+    subject { WithAClassEval.new }
+
+    module AMixinWithClassEval
+      def self.included(klass)
+        klass.class_eval do
+          after_save { |object| object.my_method }
+        end
+      end
+    end
+
+    with_model :with_a_class_eval do
+      table {}
+      model do
+        include AMixinWithClassEval
+        def my_method; end
+      end
+    end
+
+    it "should only have one after_save callback" do
+      subject.should_receive(:my_method).once
+      subject.save
+    end
+
+    it "should still only have one after_save callback in future tests" do
+      subject.should_receive(:my_method).once
+      subject.save
+    end
+  end
+
   if defined?(Mixico)
     context "after a context that uses a mixin" do
       it "should not have the mixin" do


### PR DESCRIPTION
When the module mixed-in within the `model` block contains a `class_eval` that is run when the module is included, this `class_eval` was being run before each test on the same class, causing it to unexpectedly be re-evaluated, and causing unexpected behavior in things such as included ActiveRecord callbacks.

Tests passing under 1.8.7p352 & 1.9.2p290.
