### PR TITLE
Rails 3.2 deprecations

### DIFF
--- a/lib/with_model/dsl.rb
+++ b/lib/with_model/dsl.rb
@@ -38,7 +38,7 @@ module WithModel
         model = Class.new(WithModel::Base)
         silence_warnings { Object.const_set(const_name, model) }
         Object.const_get(const_name).class_eval do
-          set_table_name table_name
+          self.table_name = table_name
           self.class_eval(&model_initialization)
         end
         model.reset_column_information


### PR DESCRIPTION
ActiveRecord::Base set_table_name is now self.table_name=
