### PR TITLE
Ensure that ActiveSupport's descendants works correctly between tests

### DIFF
--- a/lib/with_model/dsl.rb
+++ b/lib/with_model/dsl.rb
@@ -41,6 +41,9 @@ module WithModel
       end
 
       @example_group.after do
+        if model.superclass.respond_to?(:direct_descendants)
+          model.superclass.direct_descendants.delete(model)
+        end
         if defined?(ActiveSupport::Dependencies::Reference)
           ActiveSupport::Dependencies::Reference.clear!
         end

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -291,4 +291,20 @@ describe "a temporary ActiveRecord model created with with_model" do
       end
     end
   end
+
+  context "with ActiveSupport::DescendantsTracker" do
+    with_model :BlogPost
+
+    it "includes the correct model class in descendants on the first test run" do
+      ActiveRecord::Base.descendants.detect do |c|
+        c.table_name == BlogPost.table_name
+      end.should == BlogPost
+    end
+
+    it "includes the correct model class in descendants on the second test run" do
+      ActiveRecord::Base.descendants.detect do |c|
+        c.table_name == BlogPost.table_name
+      end.should == BlogPost
+    end
+  end
 end


### PR DESCRIPTION
Since `ActiveSupport::DescendantsTracker` caches the descendant classes, when we remove them, it continues to hold onto the original reference, causing `Class#descendants` to return the wrong class instance.
