### PR TITLE
Add `namespace` option to create nested constants

### DIFF
--- a/lib/with_model/constant_stubber.rb
+++ b/lib/with_model/constant_stubber.rb
@@ -1,22 +1,23 @@
 module WithModel
   class ConstantStubber
-    def initialize const_name
+    def initialize const_name, namespace
+      @namespace = namespace
       @const_name = const_name.to_sym
       @original_value = nil
     end
 
     def stub_const value
-      if Object.const_defined?(@const_name)
-        @original_value = Object.const_get(@const_name)
-        Object.send :remove_const, @const_name
+      if @namespace.const_defined?(@const_name)
+        @original_value = @namespace.const_get(@const_name)
+        @namespace.send :remove_const, @const_name
       end
 
-      Object.const_set @const_name, value
+      @namespace.const_set @const_name, value
     end
 
     def unstub_const
-      Object.send :remove_const, @const_name
-      Object.const_set @const_name, @original_value if @original_value
+      @namespace.send :remove_const, @const_name
+      @namespace.const_set @const_name, @original_value if @original_value
       @original_value = nil
     end
   end

--- a/lib/with_model/model.rb
+++ b/lib/with_model/model.rb
@@ -6,7 +6,7 @@ require 'with_model/table'
 
 module WithModel
   class Model
-    OPTIONS = [:superclass].freeze
+    OPTIONS = [:superclass, :namespace].freeze
     private_constant :OPTIONS
 
     attr_writer :model_block, :table_block, :table_options
@@ -18,6 +18,7 @@ module WithModel
       @table_block = nil
       @table_options = {}
       @superclass = options.fetch(:superclass, ActiveRecord::Base)
+      @namespace = options.fetch(:namespace, Object)
     end
 
     def create
@@ -60,7 +61,7 @@ module WithModel
     end
 
     def stubber
-      @stubber ||= ConstantStubber.new const_name
+      @stubber ||= ConstantStubber.new const_name, @namespace
     end
 
     def table

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -352,4 +352,42 @@ describe "a temporary ActiveRecord model created with with_model" do
       expect(BlogPost.with_model?).to eq true
     end
   end
+
+  context "with 'namespace' option" do
+    non_shadowing_example_ran = false
+
+    module Blogs
+      class BasePost < ActiveRecord::Base
+        self.abstract_class = true
+      end
+    end
+
+    context "a temporary model created within namespace" do
+      with_model :Post, superclass: Blogs::BasePost, namespace: Blogs do
+        table do |t|
+          t.string 'title'
+        end
+      end
+
+      after do
+        non_shadowing_example_ran = true
+      end
+
+      describe "the class" do
+        subject { Blogs::Post.new }
+        it_should_behave_like "ActiveModel"
+      end
+
+      it "responds to .with_model? with true" do
+        expect(Blogs::Post.with_model?).to eq true
+      end
+    end
+
+    context "after an example which uses with_model without shadowing an existing constant" do
+      it "returns the constant to its undefined state" do
+        expect(non_shadowing_example_ran).to eq true
+        expect(defined?(Blogs::Post)).to be_falsy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Make possible creation of namespaced models:

``` ruby
with_model :TestUser, namespace: Users, superclass: User

with_model :Test, namespace: MyModule, superclass: MyModule::Base
```
