### PR TITLE
Add minitest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ end
 
 ### minitest/spec
 
-Extend `WithModel` into minitest/spec:
+Extend `WithModel` into minitest/spec and set the test runner explicitly:
 
 ```ruby
 require 'with_model'
+
+WithModel.runner = :minitest
 
 class Minitest::Spec
   extend WithModel

--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,20 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rake/testtask'
 require 'rubocop/rake_task'
 
 desc 'Run specs'
-RSpec::Core::RakeTask.new
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+end
+
+desc 'Run tests'
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.pattern = 'test/**/*_test.rb'
+end
 
 desc 'Run lint'
 RuboCop::RakeTask.new
@@ -17,4 +27,4 @@ namespace 'doc' do
   end
 end
 
-task default: %i[spec rubocop]
+task default: %i[spec test rubocop]

--- a/lib/with_model.rb
+++ b/lib/with_model.rb
@@ -6,16 +6,25 @@ require 'with_model/table'
 require 'with_model/version'
 
 module WithModel
+  class << self
+    attr_writer :runner
+  end
+
+  def self.runner
+    @runner ||= :rspec
+  end
+
   # @param [Symbol] name The constant name to assign the model class to.
   # @param scope Passed to `before`/`after` in the test context. RSpec only.
   # @param options Passed to {WithModel::Model#initialize}.
   # @param block Yielded an instance of {WithModel::Model::DSL}.
   def with_model(name, scope: nil, **options, &block)
+    runner = options.delete(:runner)
     model = Model.new name, **options
     dsl = Model::DSL.new model
     dsl.instance_exec(&block) if block
 
-    setup_object(model, scope)
+    setup_object(model, scope: scope, runner: runner)
   end
 
   # @param [Symbol] name The table name to create.
@@ -23,17 +32,19 @@ module WithModel
   # @param options Passed to {WithModel::Table#initialize}.
   # @param block Passed to {WithModel::Table#initialize} (like {WithModel::Model::DSL#table}).
   def with_table(name, scope: nil, **options, &block)
+    runner = options.delete(:runner)
     table = Table.new name, options, &block
 
-    setup_object(table, scope)
+    setup_object(table, scope: scope, runner: runner)
   end
 
   private
 
   # @param [Object] object The new model object instance to create
   # @param scope Passed to `before`/`after` in the test context. Rspec only.
-  def setup_object(object, scope = nil)
-    if Module.const_defined? 'RSpec'
+  def setup_object(object, scope: nil, runner: nil)
+    case runner || WithModel.runner
+    when :rspec
       before(*scope) do
         object.create
       end
@@ -41,12 +52,14 @@ module WithModel
       after(*scope) do
         object.destroy
       end
-    elsif Module.const_defined? 'Minitest'
+    when :minitest
       object.create
 
       Minitest.after_run do
         object.destroy
       end
+    else
+      raise ArgumentError, "Unsupported test runner set, expected :rspec or :minitest"
     end
   end
 end

--- a/lib/with_model.rb
+++ b/lib/with_model.rb
@@ -42,7 +42,7 @@ module WithModel
 
   # @param [Object] object The new model object instance to create
   # @param scope Passed to `before`/`after` in the test context. Rspec only.
-  def setup_object(object, scope: nil, runner: nil)
+  def setup_object(object, scope: nil, runner: nil) # rubocop:disable Metrics/MethodLength
     case runner || WithModel.runner
     when :rspec
       before(*scope) do
@@ -59,7 +59,7 @@ module WithModel
         object.destroy
       end
     else
-      raise ArgumentError, "Unsupported test runner set, expected :rspec or :minitest"
+      raise ArgumentError, 'Unsupported test runner set, expected :rspec or :minitest'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Workaround for JRuby CI failure https://github.com/jruby/jruby/issues/6547#issuecomment-774104996
+if RUBY_ENGINE == 'jruby'
+  require 'i18n/backend'
+  require 'i18n/backend/simple'
+end
+
 require 'simplecov'
 SimpleCov.start
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-require 'pry'
 require 'with_model'
 require 'minitest/autorun'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
+require 'pry'
+require 'with_model'
+require 'minitest/autorun'
+
+WithModel.runner = :minitest
+
+class MiniTest::Test
+  extend WithModel
+end
+
+is_jruby = RUBY_PLATFORM == 'java'
+adapter = is_jruby ? 'jdbcsqlite3' : 'sqlite3'
+
+# WithModel requires ActiveRecord::Base.connection to be established.
+# If ActiveRecord already has a connection, as in a Rails app, this is unnecessary.
+require 'active_record'
+ActiveRecord::Base.establish_connection(adapter: adapter, database: ':memory:')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,12 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
+# Workaround for JRuby CI failure https://github.com/jruby/jruby/issues/6547#issuecomment-774104996
+if RUBY_ENGINE == 'jruby'
+  require 'i18n/backend'
+  require 'i18n/backend/simple'
+end
+
 require 'with_model'
 require 'minitest/autorun'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,10 @@ require 'minitest/autorun'
 
 WithModel.runner = :minitest
 
-class MiniTest::Test
-  extend WithModel
+module MiniTest
+  class Test
+    extend WithModel
+  end
 end
 
 is_jruby = RUBY_PLATFORM == 'java'

--- a/test/with_model_test.rb
+++ b/test/with_model_test.rb
@@ -17,7 +17,7 @@ class WithModelTest < MiniTest::Test
     end
   end
 
-  def test_it_should_act_like_a_normal_ActiveRecord_model
+  def test_it_should_act_like_a_normal_active_record_model # rubocop:disable Minitest/MultipleAssertions
     record = BlogPost.create!(title: 'New blog post', content: 'Hello, world!')
 
     record.reload

--- a/test/with_model_test.rb
+++ b/test/with_model_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WithModelTest < MiniTest::Test
+  with_model :BlogPost do
+    table do |t|
+      t.string 'title'
+      t.text 'content'
+      t.timestamps null: false
+    end
+
+    model do
+      def fancy_title
+        "Title: #{title}"
+      end
+    end
+  end
+
+  def test_it_should_act_like_a_normal_ActiveRecord_model
+    record = BlogPost.create!(title: 'New blog post', content: 'Hello, world!')
+
+    record.reload
+
+    assert_equal 'New blog post', record.title
+    assert_equal 'Hello, world!', record.content
+    assert record.updated_at
+
+    record.destroy
+
+    assert_raises ActiveRecord::RecordNotFound do
+      record.reload
+    end
+  end
+
+  def test_it_has_the_methods_defined_in_its_model_block
+    assert_equal 'Title: New blog post', BlogPost.new(title: 'New blog post').fancy_title
+  end
+end

--- a/with_model.gemspec
+++ b/with_model.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
From #30, this small change should allow for Minitest support using the same readme instructions as for RSpec.

The only differences are scope is unsupported (Minitest doesn't really have this concept) so the object is always created immediately and destroyed after the test run. I copied a couple of the basic tests into the suite to demonstrate the functionality.

Open to critical feedback, I don't love the new private method name and someone with better knowledge of Minitest internals might be able to get it to perform more similarly to RSpec (there is the suggestion of similar execution blocks [here](https://www.rubydoc.info/github/seattlerb/minitest/Minitest/Test/LifecycleHooks#before_setup-instance_method))