### PR TITLE
Use setup and teardown for parallelism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-ar_branch = ENV['ACTIVE_RECORD_BRANCH']
-ar_version = ENV['ACTIVE_RECORD_VERSION']
+ar_branch = ENV.fetch('ACTIVE_RECORD_BRANCH', nil)
+ar_version = ENV.fetch('ACTIVE_RECORD_VERSION', nil)
 is_jruby = RUBY_PLATFORM == 'java'
 
 if ar_branch

--- a/lib/with_model.rb
+++ b/lib/with_model.rb
@@ -57,13 +57,13 @@ module WithModel
       class_eval do
         cattr_accessor :with_model_object
 
-        prepend(Module.new do
-          def setup
+        include(Module.new do
+          def before_setup
             with_model_object.create
             super
           end
 
-          def teardown
+          def before_teardown
             with_model_object.destroy
             super
           end

--- a/with_model.gemspec
+++ b/with_model.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.6'


### PR DESCRIPTION
Supports parallelism in Minitest, otherwise there are race conditions between processes where the database tables are destroyed prematurely.