### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
         active-record-version-env:
           - ACTIVE_RECORD_VERSION="~> 5.2.0"
           - ACTIVE_RECORD_VERSION="~> 6.0.0"
@@ -41,6 +41,12 @@ jobs:
           - ruby-version: '3.1'
             active-record-version-env: ACTIVE_RECORD_VERSION="~> 5.2.0"
             allow-failure: false
+          - ruby-version: '3.2'
+            active-record-version-env: ACTIVE_RECORD_VERSION="~> 5.2.0"
+            allow-failure: false
+          - ruby-version: '3.2'
+            active-record-version-env: ACTIVE_RECORD_VERSION="~> 6.1.0"
+            allow-failure: false
           - ruby-version: '2.6'
             active-record-version-env: ACTIVE_RECORD_VERSION="~> 7.0.0"
             allow-failure: false
@@ -49,7 +55,7 @@ jobs:
             allow-failure: false
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Bundler/OrderedGems:
 Bundler/DuplicatedGem:
   Enabled: false
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 RSpec/Be:
   Enabled: false
 

--- a/spec/active_record_behaviors_spec.rb
+++ b/spec/active_record_behaviors_spec.rb
@@ -105,7 +105,9 @@ describe 'ActiveRecord behaviors' do
 
     context 'in earlier examples' do
       it 'works as normal' do
-        Province.create!(country: Country.create!)
+        expect do
+          Province.create!(country: Country.create!)
+        end.not_to raise_error
       end
     end
 

--- a/spec/constant_stubber_spec.rb
+++ b/spec/constant_stubber_spec.rb
@@ -4,16 +4,18 @@ require 'spec_helper'
 
 module WithModel
   describe ConstantStubber do
+    let(:stubber) { described_class.new('Foo') }
+
     it 'allows calling unstub_const multiple times' do
-      stubber = described_class.new('Foo')
-      stubber.stub_const(1)
-      stubber.unstub_const
-      stubber.unstub_const
+      expect do
+        stubber.stub_const(1)
+        stubber.unstub_const
+        stubber.unstub_const
+      end.not_to raise_error
     end
 
     it 'allows calling unstub_const without stub_const' do
-      stubber = described_class.new('Foo')
-      stubber.unstub_const
+      expect { stubber.unstub_const }.not_to raise_error
     end
   end
 end

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -14,7 +14,7 @@ shared_examples_for 'ActiveModel' do
   active_model_lint_tests.each do |method_name|
     friendly_name = method_name.tr('_', ' ')
     example friendly_name do
-      public_send method_name.to_sym
+      expect { public_send method_name.to_sym }.not_to raise_error
     end
   end
 
@@ -151,8 +151,8 @@ describe 'a temporary ActiveRecord model created with with_model' do
     with_model :'Stuff::BlogPost'
 
     it 'creates the model in the namespace' do
-      expect(defined?(::BlogPost)).to be_falsey
-      expect(defined?(::Stuff::BlogPost)).to be_truthy
+      expect(defined?(BlogPost)).to be_falsey
+      expect(defined?(Stuff::BlogPost)).to be_truthy
     end
   end
 
@@ -182,8 +182,8 @@ describe 'a temporary ActiveRecord model created with with_model' do
     end
 
     it 'has the mixin' do
-      expect(-> { ::WithAMixin.new.foo }).not_to raise_error
-      expect(::WithAMixin.include?(AMixin)).to be true
+      expect(-> { WithAMixin.new.foo }).not_to raise_error
+      expect(WithAMixin.include?(AMixin)).to be true
     end
   end
 


### PR DESCRIPTION
To get this green I had to:

1. Address a few lints
2. Disable the `Gemspec/DevelopmentDependencies` Cop (which can be re-enabled if there's a desire to shift development dependencies to the Gemfile)

I also updated the checkout action version.

Runs green on my fork.