### PR TITLE
address rubocop warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,13 @@ elsif ar_version
   end
 end
 
+gem 'bundler'
+gem 'minitest'
+gem 'rake'
+gem 'rspec'
+gem 'rubocop'
+gem 'rubocop-minitest'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+gem 'simplecov'
 gem 'sqlite3', '~> 1.5.0' unless is_jruby

--- a/spec/active_record_behaviors_spec.rb
+++ b/spec/active_record_behaviors_spec.rb
@@ -105,7 +105,7 @@ describe 'ActiveRecord behaviors' do
 
     context 'in earlier examples' do
       it 'works as normal' do
-        Province.create!(country: Country.create!)
+        expect { Province.create!(country: Country.create!) }.not_to raise_error
       end
     end
 

--- a/spec/constant_stubber_spec.rb
+++ b/spec/constant_stubber_spec.rb
@@ -7,13 +7,12 @@ module WithModel
     it 'allows calling unstub_const multiple times' do
       stubber = described_class.new('Foo')
       stubber.stub_const(1)
-      stubber.unstub_const
-      stubber.unstub_const
+      expect { 2.times { stubber.unstub_const } }.not_to raise_error
     end
 
     it 'allows calling unstub_const without stub_const' do
       stubber = described_class.new('Foo')
-      stubber.unstub_const
+      expect { stubber.unstub_const }.not_to raise_error
     end
   end
 end

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -151,8 +151,8 @@ describe 'a temporary ActiveRecord model created with with_model' do
     with_model :'Stuff::BlogPost'
 
     it 'creates the model in the namespace' do
-      expect(defined?(::BlogPost)).to be_falsey
-      expect(defined?(::Stuff::BlogPost)).to be_truthy
+      expect(defined?(BlogPost)).to be_falsey
+      expect(defined?(Stuff::BlogPost)).to be_truthy
     end
   end
 
@@ -182,8 +182,8 @@ describe 'a temporary ActiveRecord model created with with_model' do
     end
 
     it 'has the mixin' do
-      expect(-> { ::WithAMixin.new.foo }).not_to raise_error
-      expect(::WithAMixin.include?(AMixin)).to be true
+      expect(-> { WithAMixin.new.foo }).not_to raise_error
+      expect(WithAMixin.include?(AMixin)).to be true
     end
   end
 

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -13,9 +13,12 @@ shared_examples_for 'ActiveModel' do
 
   active_model_lint_tests.each do |method_name|
     friendly_name = method_name.tr('_', ' ')
+
+    # rubocop:disable RSpec/NoExpectationExample
     example friendly_name do
       public_send method_name.to_sym
     end
+    # rubocop:enable RSpec/NoExpectationExample
   end
 
   before { @model = subject }

--- a/with_model.gemspec
+++ b/with_model.gemspec
@@ -21,20 +21,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'activerecord', '>= 5.2'
-
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubocop-minitest'
-  spec.add_development_dependency 'rubocop-rake'
-  spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'simplecov'
-
-  if RUBY_PLATFORM == 'java'
-    spec.add_development_dependency 'activerecord-jdbcsqlite3-adapter'
-  else
-    spec.add_development_dependency 'sqlite3'
-  end
 end


### PR DESCRIPTION
- Rubocop: Style/RedundantConstantBase
- Move development dependencies to Gemfile
- Rubocop: RSpec/NoExpectationExample
