### PR TITLE
Drop support for EOL Ruby and Active Record

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
         active-record-version-env:
-          - ACTIVE_RECORD_VERSION="~> 5.2.0"
           - ACTIVE_RECORD_VERSION="~> 6.0.0"
           - ACTIVE_RECORD_VERSION="~> 6.1.0"
           - ACTIVE_RECORD_VERSION="~> 7.0.0"
@@ -34,16 +33,6 @@ jobs:
           - ruby-version: '3.1'
             active-record-version-env: ACTIVE_RECORD_BRANCH="6-1-stable"
             allow-failure: true
-        exclude:
-          - ruby-version: '3.0'
-            active-record-version-env: ACTIVE_RECORD_VERSION="~> 5.2.0"
-            allow-failure: false
-          - ruby-version: '3.1'
-            active-record-version-env: ACTIVE_RECORD_VERSION="~> 5.2.0"
-            allow-failure: false
-          - ruby-version: '3.1'
-            active-record-version-env: ACTIVE_RECORD_VERSION="~> 7.0.0"
-            allow-failure: false
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1']
         active-record-version-env:
           - ACTIVE_RECORD_VERSION="~> 5.2.0"
           - ACTIVE_RECORD_VERSION="~> 6.0.0"
@@ -40,9 +40,6 @@ jobs:
             allow-failure: false
           - ruby-version: '3.1'
             active-record-version-env: ACTIVE_RECORD_VERSION="~> 5.2.0"
-            allow-failure: false
-          - ruby-version: '2.6'
-            active-record-version-env: ACTIVE_RECORD_VERSION="~> 7.0.0"
             allow-failure: false
           - ruby-version: '3.1'
             active-record-version-env: ACTIVE_RECORD_VERSION="~> 7.0.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - 'bin/**/*'
     - 'vendor/bundle/**/*'

--- a/with_model.gemspec
+++ b/with_model.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
 
-  spec.add_dependency 'activerecord', '>= 5.2'
+  spec.add_dependency 'activerecord', '>= 6.0'
 end

--- a/with_model.gemspec
+++ b/with_model.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'activerecord', '>= 5.2'
 end


### PR DESCRIPTION
- Drop support for Ruby <2.7
- Drop support for Active Record <6.0
