### PR TITLE
Create table in same database as `superclass`

### DIFF
--- a/lib/with_model/model.rb
+++ b/lib/with_model/model.rb
@@ -76,7 +76,7 @@ module WithModel
     end
 
     def table
-      @table ||= Table.new table_name, @table_options, &@table_block
+      @table ||= Table.new table_name, @table_options, connection: @superclass.connection, &@table_block
     end
 
     def table_name

--- a/lib/with_model/table.rb
+++ b/lib/with_model/table.rb
@@ -8,12 +8,14 @@ module WithModel
   class Table
     # @param [Symbol] name The name of the table to create.
     # @param options Passed to ActiveRecord `create_table`.
+    # @param connection The connection to use for creating the table.
     # @param block Passed to ActiveRecord `create_table`.
     # @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-create_table
-    def initialize(name, options = {}, &block)
+    def initialize(name, options = {}, connection: ActiveRecord::Base.connection, &block)
       @name = name.freeze
       @options = options.freeze
       @block = block
+      @connection = connection
     end
 
     # Creates the table with the initialized options. Drops the table if
@@ -29,16 +31,14 @@ module WithModel
 
     private
 
+    attr_reader :connection
+
     def exists?
       if connection.respond_to?(:data_source_exists?)
         connection.data_source_exists?(@name)
       else
         connection.table_exists?(@name)
       end
-    end
-
-    def connection
-      ActiveRecord::Base.connection
     end
   end
 end

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -387,4 +387,25 @@ describe 'a temporary ActiveRecord model created with with_model' do
       expect(BlogPost.with_model?).to be true
     end
   end
+
+  context "with 'superclass' that connects to a different database" do
+    class ApplicationRecordInDifferentDatabase < ActiveRecord::Base
+      self.abstract_class = true
+      establish_connection(ActiveRecord::Base.connection_pool.db_config.configuration_hash)
+    end
+
+    after(:all) do
+      Object.__send__(:remove_const, 'ApplicationRecordInDifferentDatabase')
+    end
+
+    with_model :BlogPost, superclass: ApplicationRecordInDifferentDatabase do
+      table do |t|
+        t.string 'title'
+      end
+    end
+
+    it 'uses the superclass connection' do
+      expect(BlogPost.connection.tables).to include(BlogPost.table_name)
+    end
+  end
 end


### PR DESCRIPTION
Before this change, using `with_model` with a superclass that connects to a database other than the database configured for `ActiveRecord::Base` would end up creating the table in the wrong database. 