### PR TITLE
Satisfy current Standard style

### DIFF
--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -17,6 +17,7 @@ describe "A blog post" do
     # The model block works just like the class definition.
     model do
       include MyModule
+
       has_many :comments
       validates_presence_of :title
 

--- a/spec/with_model_spec.rb
+++ b/spec/with_model_spec.rb
@@ -209,6 +209,7 @@ describe "a temporary ActiveRecord model created with with_model" do
     with_model :WithAClassEval do
       model do
         include AMixin
+
         def my_method
         end
       end


### PR DESCRIPTION
The `standard` gem added `Layout/EmptyLinesAfterModuleInclusion`, which
flags two existing spec files:

```
spec/readme_spec.rb:19:7: C: [Corrected] Layout/EmptyLinesAfterModuleInclusion
spec/with_model_spec.rb:211:9: C: [Corrected] Layout/EmptyLinesAfterModuleInclusion
```

`bin/rake` runs `standardrb` after the specs, so it fails on a fresh
checkout of `master` even though nothing is wrong with the code.

This is the autocorrect output — a blank line after `include` in two spec
setup blocks. No behavior change, and no other file in the repo violates
the rule.