### PR TITLE
CI trigger, weekly run, and badge link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - github-actions
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: "0 18 * * 6" # Saturdays at 12pm CST
+  workflow_dispatch:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [with_model](https://github.com/Casecommons/with_model)
 
 [![Gem Version](https://img.shields.io/gem/v/with_model.svg?style=flat)](https://rubygems.org/gems/with_model)
-[![Build Status](https://github.com/Casecommons/with_model/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Casecommons/with_model/actions/workflows/ci.yml)
+[![Build Status](https://github.com/Casecommons/with_model/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Casecommons/with_model/actions/workflows/ci.yml?query=branch%3Amaster)
 [![API Documentation](https://img.shields.io/badge/yard-api%20docs-lightgrey.svg)](https://www.rubydoc.info/gems/with_model)
 
 `with_model` dynamically builds an Active Record model (with table) before each test in a group and destroys it afterwards.


### PR DESCRIPTION
Three small CI housekeeping changes, one commit each.

**Only run CI on pushes to master.** The push trigger also listed a
`github-actions` branch that no longer exists, so the only thing it could
still do was run the suite twice for a branch by that name — once for the
push and once for its pull request.

**Run CI every week** (`schedule`, Saturdays 18:00 UTC, plus
`workflow_dispatch`). The matrix includes Active Record's `main` and
`*-stable` branches, which move without anything happening here, so a break
in an unreleased Active Record currently waits for the next push to this
repository to surface. A weekly run catches it while the upstream change is
still fresh.

**Link the build badge to master's runs.** The badge image was already
pinned with `?branch=master`, but its link went to the workflow's
unfiltered run list, where a pull request's run is usually the first thing
shown — so a green badge could lead to a red run for an unmerged branch.
The link now carries `?query=branch%3Amaster` to match the image.

Two pre-existing nits in `ci.yml` are left alone here, happy to take either
in a follow-up: `actions/checkout@v3` is old enough that GitHub warns about
its Node runtime, and the `steps:` entries are indented two spaces short of
what yamllint wants.