### PR TITLE
Create minitest models in declaration order

### DIFF
--- a/lib/with_model.rb
+++ b/lib/with_model.rb
@@ -8,9 +8,13 @@ require "with_model/version"
 module WithModel
   class MiniTestLifeCycle < Module
     def initialize(object)
+      # Each with_model includes a fresh module, so the last one declared sits
+      # earliest in the ancestor chain. Calling super() first means setup runs
+      # in declaration order while teardown unwinds in reverse, which is what
+      # lets one with_model refer to another declared above it.
       define_method :before_setup do
-        object.create
         super() if defined?(super)
+        object.create
       end
 
       define_method :after_teardown do

--- a/test/declaration_order_test.rb
+++ b/test/declaration_order_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The model block is evaluated when the model is created, so a model that
+# refers to another one by constant can only work if the model it refers to
+# was created first.
+class DeclarationOrderTest < Minitest::Test
+  with_model :Author do
+    table do |t|
+      t.string "name"
+    end
+  end
+
+  with_model :Book do
+    table do |t|
+      t.integer "author_id"
+    end
+
+    model do
+      belongs_to :author, class_name: Author.name
+    end
+  end
+
+  def test_a_model_can_refer_to_one_declared_above_it
+    author = Author.create!(name: "Ursula K. Le Guin")
+    book = Book.create!(author: author)
+
+    assert_equal author, book.reload.author
+  end
+end


### PR DESCRIPTION
`MiniTestLifeCycle` ran `object.create` before `super()`. Each `with_model` includes a fresh module, so the last one declared sits earliest in the ancestor chain, which made setup run in reverse declaration order.

The effect is that a model could not refer to another model declared above it:

```ruby
class DeclarationOrderTest < Minitest::Test
  with_model :Author do
    table do |t|
      t.string "name"
    end
  end

  with_model :Book do
    table do |t|
      t.integer "author_id"
    end

    model do
      belongs_to :author, class_name: Author.name
    end
  end
end
```

`Book` was created first, so evaluating its model block raised
`NameError: uninitialized constant DeclarationOrderTest::Author`.

Swapping the declarations doesn't help. Teardown runs in reverse for the same
reason, so `Author` would be destroyed while `Book` still referred to it.

Calling `super()` first makes setup nest the way teardown already did:
outermost first, unwinding in reverse. Both hooks now agree, and so do the two
runners -- RSpec's `before`/`after` hooks have always behaved this way, which
is why the equivalent RSpec arrangement works today.

Nothing can depend on the old ordering, since referring to a later-declared
model was impossible.

Verified by reverting the fix against the new test, which fails with the
`NameError` above.