### PR TITLE
Let Dependabot keep the workflow actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,24 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
+  # Gemfile.lock is not checked in and the Gemfile deliberately leaves versions
+  # to Bundler, so there is nothing here for Dependabot to bump routinely. It is
+  # listed to receive security advisories for the constraints that do exist.
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+    open-pull-requests-limit: 10
+
+  # The workflow pins actions by major version, which does not float across
+  # majors: actions/checkout sat four majors behind until someone noticed by
+  # hand. One grouped pull request keeps them current without a PR per action.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,13 @@ jobs:
             allow-failure: true
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
-    - name: Update bundle
-      run: ${{ matrix.active-record-version-env }} bundle update
-    - name: Run tests
-      run: ${{ matrix.active-record-version-env }} bin/rake
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Update bundle
+        run: ${{ matrix.active-record-version-env }} bundle update
+      - name: Run tests
+        run: ${{ matrix.active-record-version-env }} bin/rake

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010–2022 Casebook, PBC <http://www.casebook.net>
+Copyright (c) 2010–2026 Casebook, PBC <http://www.casebook.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -271,5 +271,5 @@ In general, `with_model` is not guaranteed to be thread-safe, but is, in certain
 
 ## License
 
-Copyright © 2010–2022 [Casebook PBC](https://www.casebook.net).
+Copyright © 2010–2026 [Casebook PBC](https://www.casebook.net).
 Licensed under the MIT license, see [LICENSE](/LICENSE) file.


### PR DESCRIPTION
Housekeeping surfaced while closing out #61.

### Dependabot was watching the wrong thing

`.github/dependabot.yml` has existed since January 2022, listing only `bundler` — which has nothing to do here. `Gemfile.lock` is not checked in, and the only two version constraints in the repository are deliberate: a floor of Active Record 7.0 in the gemspec, and a ceiling of sqlite3 1.x for the matrix leg that tests against it. Any pull request Dependabot could open against either would be one to close.

The ecosystem that *did* have something to say was never listed. `actions/checkout` was four majors behind, and the only reason it came up is that it emits a Node-runtime deprecation warning on every job, which I noticed by hand rather than being told. So `github-actions` is listed now — grouped into a single pull request rather than one per action, and weekly on the day the scheduled build already runs rather than daily.

`actions/checkout` goes to v7 here, since that is the bump nobody was told about. Its `steps:` are also indented under the sequence key, matching the rest of the file and the new config; the YAML parses identically either way.

### Copyright years

2022 → 2026 in `LICENSE` and the README.

### Not addressed

Dependabot reports a low-severity use-after-free in `sqlite3 <= 2.9.4`, patched in 2.9.5. The unpinned legs already resolve to 2.9.5, so they are clear. The `ACTIVE_RECORD_VERSION="~> 7.0.0"` and `ACTIVE_RECORD_BRANCH="7-0-stable"` legs cannot be: Active Record 7.0's sqlite3 adapter requires `sqlite3 ~> 1.4`, so `< 2` is load-bearing rather than stale. I confirmed that by removing the pin — Bundler resolves it happily, then every example errors with `can't activate sqlite3 (~> 1.4), already activated sqlite3-2.9.5`.

That leaves the alert open for as long as Active Record 7.0 is supported. It is a test-only dependency of a testing gem, and not a dependency of `with_model` itself, so nothing installing this gem is exposed. Worth a decision on whether to keep 7.0 in the matrix, but not one to make in this pull request.

Each commit passes `bin/rake` on its own.
