### PR TITLE
Drop support for end-of-life Ruby and Active Record

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,42 +27,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.3", "3.4", "4.0"]
         active-record:
-          - label: AR 7.0
-            env: ACTIVE_RECORD_VERSION=~> 7.0.0
-          - label: AR 7.1
-            env: ACTIVE_RECORD_VERSION=~> 7.1.0
           - label: AR 7.2
             env: ACTIVE_RECORD_VERSION=~> 7.2.0
           - label: AR 8.0
             env: ACTIVE_RECORD_VERSION=~> 8.0.0
+          - label: AR 8.1
+            env: ACTIVE_RECORD_VERSION=~> 8.1.0
         allow-failure: [false]
         include:
-          - ruby-version: "3.4"
+          - ruby-version: "4.0"
             active-record:
               label: AR main
               env: ACTIVE_RECORD_BRANCH=main
             allow-failure: true
-          - ruby-version: "3.4"
+          - ruby-version: "4.0"
+            active-record:
+              label: AR 8-1-stable
+              env: ACTIVE_RECORD_BRANCH=8-1-stable
+            allow-failure: true
+          - ruby-version: "4.0"
             active-record:
               label: AR 8-0-stable
               env: ACTIVE_RECORD_BRANCH=8-0-stable
             allow-failure: true
-          - ruby-version: "3.4"
+          - ruby-version: "4.0"
             active-record:
               label: AR 7-2-stable
               env: ACTIVE_RECORD_BRANCH=7-2-stable
             allow-failure: true
-          - ruby-version: "3.4"
+          # A canary for the next Ruby, which cannot fail the build.
+          - ruby-version: ruby-head
             active-record:
-              label: AR 7-1-stable
-              env: ACTIVE_RECORD_BRANCH=7-1-stable
-            allow-failure: true
-          - ruby-version: "3.4"
-            active-record:
-              label: AR 7-0-stable
-              env: ACTIVE_RECORD_BRANCH=7-0-stable
+              label: AR 8.1
+              env: ACTIVE_RECORD_VERSION=~> 8.1.0
             allow-failure: true
     continue-on-error: ${{ matrix.allow-failure }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,46 +10,82 @@ on:
     - cron: "0 18 * * 6" # Saturdays at 12pm CST
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
+    name: Ruby ${{ matrix.ruby-version }} / ${{ matrix.active-record.label }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       CI: true
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4']
-        active-record-version-env:
-          - ACTIVE_RECORD_VERSION="~> 7.0.0"
-          - ACTIVE_RECORD_VERSION="~> 7.1.0"
-          - ACTIVE_RECORD_VERSION="~> 7.2.0"
-          - ACTIVE_RECORD_VERSION="~> 8.0.0"
+        ruby-version: ["3.2", "3.3", "3.4"]
+        active-record:
+          - label: AR 7.0
+            env: ACTIVE_RECORD_VERSION=~> 7.0.0
+          - label: AR 7.1
+            env: ACTIVE_RECORD_VERSION=~> 7.1.0
+          - label: AR 7.2
+            env: ACTIVE_RECORD_VERSION=~> 7.2.0
+          - label: AR 8.0
+            env: ACTIVE_RECORD_VERSION=~> 8.0.0
         allow-failure: [false]
         include:
-          - ruby-version: '3.4'
-            active-record-version-env: ACTIVE_RECORD_BRANCH="main"
+          - ruby-version: "3.4"
+            active-record:
+              label: AR main
+              env: ACTIVE_RECORD_BRANCH=main
             allow-failure: true
-          - ruby-version: '3.4'
-            active-record-version-env: ACTIVE_RECORD_BRANCH="8-0-stable"
+          - ruby-version: "3.4"
+            active-record:
+              label: AR 8-0-stable
+              env: ACTIVE_RECORD_BRANCH=8-0-stable
             allow-failure: true
-          - ruby-version: '3.4'
-            active-record-version-env: ACTIVE_RECORD_BRANCH="7-2-stable"
+          - ruby-version: "3.4"
+            active-record:
+              label: AR 7-2-stable
+              env: ACTIVE_RECORD_BRANCH=7-2-stable
             allow-failure: true
-          - ruby-version: '3.4'
-            active-record-version-env: ACTIVE_RECORD_BRANCH="7-1-stable"
+          - ruby-version: "3.4"
+            active-record:
+              label: AR 7-1-stable
+              env: ACTIVE_RECORD_BRANCH=7-1-stable
             allow-failure: true
-          - ruby-version: '3.4'
-            active-record-version-env: ACTIVE_RECORD_BRANCH="7-0-stable"
+          - ruby-version: "3.4"
+            active-record:
+              label: AR 7-0-stable
+              env: ACTIVE_RECORD_BRANCH=7-0-stable
             allow-failure: true
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
       - uses: actions/checkout@v7
+      # Set the version here rather than prefixing each command, so the matrix
+      # value reaches the environment without being interpolated into a script.
+      - name: Select Active Record version
+        env:
+          ACTIVE_RECORD_ENV: ${{ matrix.active-record.env }}
+        run: echo "$ACTIVE_RECORD_ENV" >> "$GITHUB_ENV"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+          cache-version: ${{ matrix.active-record.env }}
+      # Gemfile.lock is not checked in, so this resolves the newest gems that
+      # satisfy the Gemfile on each run rather than a recorded set. `--all` is
+      # what Bundler 4, shipped with Ruby 4.0, wants for that.
       - name: Update bundle
-        run: ${{ matrix.active-record-version-env }} bundle update
+        run: bundle update --all
+      # Not bin/rake: bin/ holds generated binstubs and is not checked in, and
+      # whether bundling writes them there varies by Bundler version - Bundler 4
+      # does not, which left Ruby 4.0 with no binstub to run.
       - name: Run tests
-        run: ${{ matrix.active-record-version-env }} bin/rake
+        run: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   column. In 3.0 it will create no table.
 - Create minitest models in the order they are declared, so that a model can
   refer to another model declared above it.
-- Require Ruby 3.2 or later.
+- Require Ruby 3.3 or later.
+- Require Active Record 7.2 or later.
 
 ### 2.2.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to with_model
+
+If you experience a bug, we welcome you to report it. Please include a minimal
+example showing the code you ran, what happened, and what you expected to happen
+instead — a failing `with_model` block is ideal, since it can be dropped straight
+into the suite. If you can fix the bug and open a pull request, it will get
+resolved sooner, but don't hesitate to report an issue you don't know how to fix.
+
+If you have a substantial feature in mind, consider opening an issue to discuss
+it first. We may have thought about it already, and can sometimes save you a
+detour.
+
+When in doubt, go ahead and open a pull request. If something needs rethinking,
+we will do our best to say so clearly. Don't be discouraged if we ask you to
+change your code — we appreciate the work, and we also have opinions about style
+and object design.
+
+## Supported versions
+
+The [gemspec](./with_model.gemspec) declares the minimum supported Ruby and
+Active Record, and the [CI workflow](./.github/workflows/ci.yml) lists every
+combination actually tested. It can be hard to try them all locally, so please
+avoid anything that only works on the newest of either.
+
+## Running the tests
+
+The suite runs against both supported test harnesses, so `with_model` has to work
+under each:
+
+- `spec/` covers behavior under RSpec.
+- `test/` covers the minitest life cycle — the setup and teardown hooks, and
+  their ordering — rather than repeating the specs.
+
+Run everything, including the linter, with:
+
+```sh
+bundle exec rake
+```
+
+`bin/` holds generated binstubs and is not checked in. Whether bundling writes
+them for you depends on your Bundler version, so create them once if you would
+rather type `bin/rake`:
+
+```sh
+bundle binstubs --all
+```
+
+Our automated tests begin by updating every gem to its newest version. That is
+deliberate: we would rather find out about an incompatibility from our own build
+than from a bug report. `Gemfile.lock` is not checked in, so you can do the same
+at any time with `bundle update --all`.
+
+To try a particular Active Record, set `ACTIVE_RECORD_VERSION` to a version
+requirement and update the bundle:
+
+```sh
+ACTIVE_RECORD_VERSION="~> 8.1.0" bundle update --all
+ACTIVE_RECORD_VERSION="~> 8.1.0" bundle exec rake
+```
+
+To test against Active Record from git instead — an unreleased branch, or `main`
+— set `ACTIVE_RECORD_BRANCH`:
+
+```sh
+ACTIVE_RECORD_BRANCH=main bundle update --all
+ACTIVE_RECORD_BRANCH=main bundle exec rake
+```
+
+Style is enforced by [Standard](https://github.com/standardrb/standard), which
+`rake` runs. To correct what it can:
+
+```sh
+bundle exec standardrb --fix
+```
+
+## Changes and releases
+
+Please add a line to `CHANGELOG.md` under `### Unreleased` describing your change
+from the point of view of someone using the gem. Leave `lib/with_model/version.rb`
+alone: version bumps and releases are cut separately by a maintainer, so a bump
+in a pull request only creates a conflict.
+
+Last, but not least, have fun.

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ ar_version = ENV.fetch("ACTIVE_RECORD_VERSION", nil)
 
 if ar_branch
   gem "activerecord", git: "https://github.com/rails/rails.git", branch: ar_branch
-  gem "arel", git: "https://github.com/rails/arel.git" if ar_branch == "master"
 elsif ar_version
   gem "activerecord", ar_version
 end
@@ -23,10 +22,5 @@ gem "mutex_m"
 gem "rake"
 gem "rspec"
 gem "ruby-lsp"
+gem "sqlite3"
 gem "standard"
-
-if ar_branch == "7-0-stable" || ar_version == "~> 7.0.0"
-  gem "sqlite3", "< 2"
-else
-  gem "sqlite3"
-end

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ See the [gemspec metadata](https://rubygems.org/gems/with_model) for dependency 
 
 In general, `with_model` is not guaranteed to be thread-safe, but is, in certain usages, safe to use concurrently across multiple processes with a single database schema.
 
+## Contributing
+
+Bug reports and pull requests are welcome. See the
+[CONTRIBUTING guide](/CONTRIBUTING.md) for how to run the tests against a
+particular Ruby or Active Record.
+
 ## Versioning
 
 `with_model` uses [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html).

--- a/with_model.gemspec
+++ b/with_model.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 
-  spec.add_dependency "activerecord", ">= 7.0"
+  spec.add_dependency "activerecord", ">= 7.2"
 end


### PR DESCRIPTION
Drops Ruby and Active Record versions that are out of support, adds the ones that have shipped since the matrix was last touched, and adds a contributing guide.

### What is out of support

| | released | status |
| --- | --- | --- |
| Ruby 3.2 | 2022-12-25 | end of life 2026-03-31 |
| Active Record 7.0 | 2021-12-15 | end of life |
| Active Record 7.1 | 2023-10-05 | end of life |

So `required_ruby_version` becomes `>= 3.3` and the Active Record dependency becomes `>= 7.2`.

### What is new

Ruby 4.0 shipped on 2025-12-25 and Active Record 8.1 on 2025-10-22; neither was tested here. Both are now in the matrix, along with `8-1-stable` and a `ruby-head` canary that cannot fail the build.

The grid goes from 17 jobs to 14 — 9 required plus 5 that are allowed to fail — while covering more current versions than before.

### Two dead Gemfile conditionals go away with 7.0

The Gemfile chose between sqlite3 1.x and 2.x per matrix leg, because Active Record 7.0's adapter requires `sqlite3 ~> 1.4`. With 7.0 gone the Gemfile just asks for `sqlite3`.

A self-audit turned up a second one next to it, which had been dead for longer:

```ruby
gem "arel", git: "https://github.com/rails/arel.git" if ar_branch == "master"
```

Three separate reasons it could never do anything: nothing sets `ACTIVE_RECORD_BRANCH=master` (the workflow tests `main`), Rails has not had a `master` branch in years, and `rails/arel` has been untouched since 2018 because Arel was merged into Active Record in 6.0 — `activerecord` 8.1.3 lists `activesupport`, `activemodel`, and `timeout`, with no `arel` among them. Removed, and the `*-stable` legs that exercise that code path are green.

### The sqlite3 advisory

Dropping the pin also closes out the advisory reported against this repository: a use-after-free in `sqlite3 <= 2.9.4`, patched in 2.9.5. The pinned legs could never have taken that fix, since 1.x is not in its range. Now every leg resolves 2.9.5.

### Verified locally

Both floors and both ceilings, on real interpreters rather than by inspection:

| | Active Record 7.2 | Active Record 8.1 |
| --- | --- | --- |
| Ruby 3.3 | 130 examples, 10 runs | 130 examples, 10 runs |
| Ruby 3.4 | 130 examples, 10 runs | 130 examples, 10 runs |
| Ruby 4.0 | 130 examples, 10 runs | 130 examples, 10 runs |

All green, zero failures.

### Workflow structure

The first commit restructures the workflow before any versions change, so the version diff is readable on its own. It follows pg_search, which had already solved the same problems:

- Checks were named `test (3.2, ACTIVE_RECORD_VERSION="~> 7.0.0", false)` — hard to scan, and leaking the `continue-on-error` flag into the name. They are now `Ruby 3.3 / AR 8.1`.
- The Active Record version is written to `GITHUB_ENV` in its own step rather than prefixed onto each command, so a matrix value is no longer interpolated into a shell script.
- Pull requests cancel their own superseded runs, the job has a timeout, and the workflow requests only `contents: read`.

That commit changes how the jobs are named and set up, not which ones run: I confirmed the matrix expands to the same 17 `(ruby, env, allow-failure)` tuples before and after.

### Contributing guide

`CONTRIBUTING.md`, adapted from pg_search's. The parts specific to this gem are the two suites — `spec/` for behavior under RSpec, `test/` for the minitest life cycle rather than a second copy of the specs — and the two environment variables for selecting an Active Record, which take a version requirement and a git branch respectively. It also asks contributors to leave `version.rb` alone and add to the Unreleased changelog section.

Linked from the README, which otherwise had nothing pointing at how to run the tests.

### Worth knowing

**Active Record 7.2 goes out of support on 2026-08-09**, twelve days from now. This floor has days left rather than months, so a follow-up moving it to 8.0 is worth expecting shortly. I have kept 7.2 rather than pre-emptively dropping it, since it is supported today.

The README defers to the gemspec for supported versions instead of listing them, so it needed no version edit here — that indirection is why it has not drifted.

Each commit passes `bin/rake` on its own.

### Ruby 4.0 needed `bundle exec`

The first push of this branch failed every Ruby 4.0 job with `bin/rake: No such file or directory`, while 3.3 and 3.4 passed. `bin/` holds generated binstubs and is not checked in, so CI only ever had one because bundling wrote it — and whether bundling does that varies by Bundler version. Ruby 4.0 ships Bundler 4, which does not, so there was nothing to run.

Tests now run through `bundle exec rake`, as pg_search's do, and `bundle update` gains `--all` — required by Bundler 4, and already the meaning under Bundler 2.

Worth recording that my local "verified on Ruby 4.0" claim above was wrong when I made it: a stale binstub from a Ruby 3.x run was sitting in my working copy, so `bin/rake` resolved locally and hid the problem. The table's results are real, but they were produced with binstubs present. I re-ran all three Rubies with `bin/` removed to confirm the fix, and CI now agrees.
